### PR TITLE
solved issue #19: geminio command throwing EISDIR error when source i…

### DIFF
--- a/geminio.js
+++ b/geminio.js
@@ -12,6 +12,14 @@ else{
 	var destination = process.argv[3];
 
 	if(fs.existsSync(source)){
+		const srcStats = fs.statSync(source);
+		const destStats = fs.statSync(destination);
+
+		if (srcStats.isFile() && destStats.isDirectory()){
+			const temp = source.split('/');
+			destination += '/' + temp[temp.length - 1];
+		}
+
 		fs.copy(source,destination,err => {
 			if(err){
 				return console.log(err);


### PR DESCRIPTION
- For 'geminio' command to work, both source and destination paths need to be file paths
- It breaks if destination path is a directory
- It is fairly common to give just the path to destination directory to 'cp' command
- So to fix this issue, I'm first checking if the destination is a directory path. If yes, I'm copying the file name (from source path) and appending it to the destination path
- tested it, attaching screenshot
![screenshot from 2018-10-08 20-06-23](https://user-images.githubusercontent.com/27222520/46616856-1161da00-cb39-11e8-9a21-e89dbbc66880.png)


